### PR TITLE
PR requirements.txt y .gitignore 

### DIFF
--- a/equipo2-consultorio-main/.gitignore
+++ b/equipo2-consultorio-main/.gitignore
@@ -5,3 +5,5 @@ env/
 *.db
 *.sqlite3
 .DS_Store
+
+# actualizado desde feature/setup-files

--- a/equipo2-consultorio-main/requirements.txt
+++ b/equipo2-consultorio-main/requirements.txt
@@ -1,3 +1,4 @@
+# deps iniciales
 blinker==1.9.0
 click==8.3.0
 colorama==0.4.6


### PR DESCRIPTION
Cambio:  Se añaden/ajustan los archivos de configuración inicial del proyecto.
- requirements.txt con dependencias base (Flask)
- .gitignore para excluir .venv, __pycache__, *.pyc, etc.

Cómo probar:
1) pip install -r requirements.txt
2) Verificar que .venv/ y __pycache__/ no se incluyan en cambios (git status limpio).


Archivos tocados:
requirements.txt
.gitignore

Revisor:  @victorrpt-teacher
